### PR TITLE
Fixed stripping of XML-Header

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -377,7 +377,7 @@ class CssToInlineStyles
             $html = $document->saveXML(null, LIBXML_NOEMPTYTAG);
 
             // remove the XML-header
-            $html = ltrim(preg_replace('/<?xml (.*)?>/', '', $html));
+            $html = ltrim(preg_replace('/<\?xml (.*)\?>/', '', $html));
         } // just regular HTML 4.01 as it should be used in newsletters
         else {
             // get the HTML


### PR DESCRIPTION
The regular expression to remove the xml-header was not properly escaped.
Fixes #96